### PR TITLE
Redirect clients when pointing at a static subdirectory without a trailing slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Handling mimetypes other than `text/gemini`. Clients would have to download them instead of trying to display them. Example app is amended.
 * Added mimetype of response to the access log.
 * Added documentation for Handlers.
+* Redirect clients when pointing at a static subdirectory without a trailing slash. It caused misdirections because the client was requesting the "/document.gmi" instead of the "/subdir/document.gmi".
 
 ## v0.0.1 (2020-12-04)
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Most of the time, when working with `Handler` basic classes, you'll have to impl
 
 #### StaticHandler
 
-This handler is used for serving a static directory.
+This handler is used for serving a static directory and its subdirectories.
 
 How to instantiate:
 
@@ -147,9 +147,11 @@ StaticHandler(
 )
 ```
 
-* `static_dir`: the path (relative to your program or absolute) of the root directory to serve. The program will also serve subdirectories.
+* `static_dir`: the path (relative to your program or absolute) of the root directory to serve.
 * `directory_listing` (default: `True`): if set to `True`, in case there's no "index file" in a directory, the application will display the directory listing. If set to `False`, and if there's still no index file in this directory, it'll return a `NotFoundResponse` to the client.
 * `index_file` (default: `"index.gmi"`): when the client tries to reach a directory, it's this filename that would be searched to be rendered as the "homepage".
+
+*Note*: If your client is trying to reach a subdirectory like this: `gemini://localhost/subdirectory` (without the trailing slash), the client will receive a Redirection Response targetting `gemini://localhost/subdirectory/` (with the trailing slash).
 
 #### TemplateHandler
 

--- a/gemeaux/handlers.py
+++ b/gemeaux/handlers.py
@@ -1,7 +1,12 @@
 from os.path import abspath, isdir, isfile, join
 
 from .exceptions import ImproperlyConfigured
-from .responses import DirectoryListingResponse, DocumentResponse, TemplateResponse
+from .responses import (
+    DirectoryListingResponse,
+    DocumentResponse,
+    RedirectResponse,
+    TemplateResponse,
+)
 
 
 class Handler:
@@ -59,6 +64,9 @@ class StaticHandler(Handler):
         # print(f"StaticHandler: path='{full_path}'")
         # The path leads to a directory
         if isdir(full_path):
+            # Directory. Redirect if not root?
+            if path and not path.endswith("/"):
+                return RedirectResponse(f"{path}/")
             # Directory -> index?
             index_path = join(full_path, self.index_file)
             if isfile(index_path):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -6,6 +6,7 @@ from gemeaux import (
     DirectoryListingResponse,
     DocumentResponse,
     ImproperlyConfigured,
+    RedirectResponse,
     StaticHandler,
     TemplateHandler,
     TemplateResponse,
@@ -55,6 +56,12 @@ def test_static_handler_subdir(index_directory, sub_content):
     assert isinstance(response, DirectoryListingResponse)
     assert response.content.startswith(b"# Directory listing for `/subdir`\r\n")
 
+    # No Index + No slash -> Directory Listing
+    handler = StaticHandler(index_directory)
+    response = handler.get_response("", "/subdir")
+    assert isinstance(response, RedirectResponse)
+    assert response.target == "subdir/"
+
 
 def test_static_handler_sub_url(index_directory, index_content):
     handler = StaticHandler(index_directory)
@@ -87,9 +94,10 @@ def test_static_handler_no_directory_listing(
     assert isinstance(response, DocumentResponse)
     assert response.content == bytes(index_content, encoding="utf-8")
 
-    # Subdir -> no index -> no directory listing
-    with pytest.raises(FileNotFoundError):
-        handler.get_response("", "/subdir")
+    # Subdir + no slash -> Redirect to "/"
+    response = handler.get_response("", "/subdir")
+    assert isinstance(response, RedirectResponse)
+    assert response.target == "subdir/"
 
     # Subdir -> no index -> no directory listing
     with pytest.raises(FileNotFoundError):

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 envlist = lint,py36,py37,py38
 
 [testenv]
-deps = pytest
+deps =
+    pytest
 commands = pytest
 
 


### PR DESCRIPTION

It caused misdirections because the client was requesting the "/document.gmi" instead of the "/subdir/document.gmi".