### PR TITLE
v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,23 @@
 # Gemeaux changelog
 
-## master (unreleased)
+## v0.0.2 (2020-12-07)
+
+### Following the Specs
 
 * Added `TemplateResponse` & `TemplateHandler` classes for generating Gemini content using template files.
-* Improved conftest for pytest using fixtures for document content.
 * Make sure returned responses endlines are not mixed, only CRLF.
-* Return version number when using the `--version` option.
-* Display version number at startup on the welcome message.
 * Handling mimetypes other than `text/gemini`. Clients would have to download them instead of trying to display them. Example app is amended.
-* Added mimetype of response to the access log.
-* Added documentation for Handlers.
 * Redirect clients when pointing at a static subdirectory without a trailing slash. It caused misdirections because the client was requesting the "/document.gmi" instead of the "/subdir/document.gmi".
 * Improve application resilience after auditing it with [gemini-diagnostic](https://github.com/michael-lazar/gemini-diagnostics). Everything is not perfect, but that's a good start, to be honest.
 * Added `BadRequestResponse`, `ProxyRequestRefusedResponse` classes
+
+### Other changes
+
+* Improved conftest for pytest using fixtures for document content.
+* Return version number when using the `--version` option.
+* Display version number at startup on the welcome message.
+* Added mimetype of response to the access log.
+* Added documentation for Handlers.
 
 ## v0.0.1 (2020-12-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gemeaux changelog
 
+## master (unreleased)
+
+Nothing here yet.
+
 ## v0.0.2 (2020-12-07)
 
 ### Following the Specs

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gemeaux: a Python Gemini Server
 
-![travis build badge for "main" branch](https://travis-ci.com/brunobord/gemeaux.svg?branch=main)
+![travis build badge for "main" branch](https://travis-ci.com/brunobord/gemeaux.svg?branch=main) [![PyPI version of gemeaux](https://badge.fury.io/py/gemeaux.svg)](https://pypi.python.org/pypi/gemeaux/)
 
 The [Gemini protocol](https://gemini.circumlunar.space/) is an ongoing initiative to build a clutter-free content-focused Internet browsing, *à la* [Gopher](https://en.wikipedia.org/wiki/Gopher_(protocol)), but modernized. It focuses on Privacy (TLS + no user tracking) and eliminates the fluff around the modern web: cookies, ads, overweight Javascript apps, browser incompatibilities, etc.
 

--- a/gemeaux/__init__.py
+++ b/gemeaux/__init__.py
@@ -32,7 +32,7 @@ from .responses import (
     crlf,
 )
 
-__version__ = "0.0.2"
+__version__ = "0.0.3.dev0"
 
 
 class Config:

--- a/gemeaux/__init__.py
+++ b/gemeaux/__init__.py
@@ -32,7 +32,7 @@ from .responses import (
     crlf,
 )
 
-__version__ = "0.0.2.dev0"
+__version__ = "0.0.2"
 
 
 class Config:


### PR DESCRIPTION
### Following the Specs

* Added `TemplateResponse` & `TemplateHandler` classes for generating Gemini content using template files.
* Make sure returned responses endlines are not mixed, only CRLF.
* Handling mimetypes other than `text/gemini`. Clients would have to download them instead of trying to display them. Example app is amended.
* Redirect clients when pointing at a static subdirectory without a trailing slash. It caused misdirections because the client was requesting the "/document.gmi" instead of the "/subdir/document.gmi".
* Improve application resilience after auditing it with [gemini-diagnostic](https://github.com/michael-lazar/gemini-diagnostics). Everything is not perfect, but that's a good start, to be honest.
* Added `BadRequestResponse`, `ProxyRequestRefusedResponse` classes

### Other changes

* Improved conftest for pytest using fixtures for document content.
* Return version number when using the `--version` option.
* Display version number at startup on the welcome message.
* Added mimetype of response to the access log.
* Added documentation for Handlers.