### PR TITLE
added option SO_REUSEADDR to the server

### DIFF
--- a/gemeaux/__init__.py
+++ b/gemeaux/__init__.py
@@ -3,7 +3,7 @@ import ssl
 import sys
 import time
 from argparse import ArgumentParser
-from socket import AF_INET, SOCK_STREAM, socket, SOL_SOCKET, SO_REUSEADDR
+from socket import AF_INET, SO_REUSEADDR, SOCK_STREAM, SOL_SOCKET, socket
 from ssl import PROTOCOL_TLS_SERVER, SSLContext
 from urllib.parse import urlparse
 

--- a/gemeaux/__init__.py
+++ b/gemeaux/__init__.py
@@ -3,7 +3,7 @@ import ssl
 import sys
 import time
 from argparse import ArgumentParser
-from socket import AF_INET, SOCK_STREAM, socket
+from socket import AF_INET, SOCK_STREAM, socket, SOL_SOCKET, SO_REUSEADDR
 from ssl import PROTOCOL_TLS_SERVER, SSLContext
 from urllib.parse import urlparse
 
@@ -289,6 +289,7 @@ class App:
         context.load_cert_chain(self.config.certfile, self.config.keyfile)
 
         with socket(AF_INET, SOCK_STREAM) as server:
+            server.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
             server.bind((self.config.ip, self.config.port))
             server.listen(self.config.nb_connections)
             print(self.BANNER)


### PR DESCRIPTION
I added the option SO_REUSEADDR to the severs socket. This lets you rebind the port/address faster and you don't have to wait for the timeout.