### PR TITLE
Fixed https://github.com/brunobord/gemeaux/issues/13

### DIFF
--- a/gemeaux/__init__.py
+++ b/gemeaux/__init__.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import ssl
 import sys
 import time
@@ -134,7 +134,7 @@ class App:
 
     def __init__(self, urls, config=None):
         # Check the urls
-        if not isinstance(urls, collections.Mapping):
+        if not isinstance(urls, collections.abc.Mapping):
             # Not of the dict type
             raise ImproperlyConfigured("Bad url configuration: not a dict or dict-like")
 


### PR DESCRIPTION
Fixed https://github.com/brunobord/gemeaux/issues/13

According to https://stackoverflow.com/questions/70195545/how-to-fix-attributeerror-module-collections-has-no-attribute-mapping-wit, Mapping was moved from collections to collections.abc fully in 3.10. This change should allow it to run on more modern version of python, as well as python versions going back to 3.3.

Ive tested this change in my "geminipfs" project and it seems like it works. 