### PR TITLE
Modernize even more

### DIFF
--- a/.github/workflows/tox-tests.yaml
+++ b/.github/workflows/tox-tests.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.9"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tox-tests.yaml
+++ b/.github/workflows/tox-tests.yaml
@@ -1,4 +1,4 @@
-name: Python package
+name: Python package tests
 
 on: [push]
 
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9"]
+        python: ["3.9"]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Drop support for Python 3.8
 * Added a small badge for GH workflows
 * Confirm support of Python 3.10, 3.11, 3.12, 3.13
+* Updating links to the Gemini Protocol canonical website and Bollux project page on the README
 
 ## v0.0.2 (2020-12-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Added the option SO_REUSEADDR to the severs socket. Thanks @airmack (#11)
 * Drop support for Python 3.8
 * Added a small badge for GH workflows
+* Confirm support of Python 3.10, 3.11, 3.12, 3.13
 
 ## v0.0.2 (2020-12-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Switched from Travis CI to Github Workflows
 * Added the option SO_REUSEADDR to the severs socket. Thanks @airmack (#11)
 * Drop support for Python 3.8
+* Added a small badge for GH workflows
 
 ## v0.0.2 (2020-12-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Removed support of Python 3.6 and 3.7.
 * Switched from Travis CI to Github Workflows
 * Added the option SO_REUSEADDR to the severs socket. Thanks @airmack (#11)
+* Drop support for Python 3.8
 
 ## v0.0.2 (2020-12-07)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Gemeaux: a Python Gemini Server
 
+![Python tests](https://github.com/brunobord/gemeaux/actions/workflows/tox-tests.yaml/badge.svg)
+
 [![PyPI version of gemeaux](https://badge.fury.io/py/gemeaux.svg)](https://pypi.python.org/pypi/gemeaux/) [![PyPI license](https://img.shields.io/pypi/l/gemeaux.svg)](https://pypi.python.org/pypi/gemeaux/) [![PyPI pyversions](https://img.shields.io/pypi/pyversions/gemeaux.svg)](https://pypi.python.org/pypi/gemeaux/)
 
 The [Gemini protocol](https://gemini.circumlunar.space/) is an ongoing initiative to build a clutter-free content-focused Internet browsing, *à la* [Gopher](https://en.wikipedia.org/wiki/Gopher_(protocol)), but modernized. It focuses on Privacy (TLS + no user tracking) and eliminates the fluff around the modern web: cookies, ads, overweight Javascript apps, browser incompatibilities, etc.

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ For development purposes, I'd recommend [bollux](https://sr.ht/~acdw/bollux/), a
 
 ## Requirements
 
-`Gemeaux` is built around **the standard Python 3.8+ library** and syntax. There are **no external dependencies**.
+`Gemeaux` is built around **the standard Python 3.9+ library** and syntax. There are **no external dependencies**.
 
-Automated tests are launched using Python 3.8 and 3.9, so the internals of `Gemeaux` are safe with these versions of Python.
+Automated tests are launched using Python 3.9, so the internals of `Gemeaux` are safe with these versions of Python.
 
 You'll also need `openssl` to generate certificates.
 
@@ -397,7 +397,7 @@ You can pass as many context variables as you want, but here are some important 
 
 This project is mostly for education purposes, although it can possibly be used through a local network, serving Gemini content. There are important steps & bugs to fix before becoming a more solid alternative to other Gemini server software.
 
-* The internals of `Gemeaux` are being tested on Python3.8+, but not the mainloop mechanics.
+* The internals of `Gemeaux` are being tested on Python3.9+, but not the mainloop mechanics.
 * The vast majority of Gemini Standard responses are not implemented.
 * The Response documentation is missing, along with docstrings.
 * Performances are probably very low, there might be room for optimisation.

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ So, here it is: the `Gemeaux` server.
 
 A quick word about Gemini protocol. Since it's a different protocol from HTTP, or Gopher, or FTP, etc., it means that you'll have to drop your beloved Web Browser to access Gemini content. Hopefully, several clients are available.
 
-* [A list of clients on the canonical Gemini Space](https://gemini.circumlunar.space/clients.html)
+* [A list of clients on the canonical Gemini Space](https://geminiprotocol.net/clients.html)
 * [A curated list of clients on "awesome Gemini"](https://github.com/kr1sp1n/awesome-gemini#clients)
 
 Download and install a couple of clients, pick one that fits your needs, or if you feel like it, build one yourself, and you'll be ready to spacewalk the Gemini ecosystem.
 
-For development purposes, I'd recommend [bollux](https://sr.ht/~acdw/bollux/), a browser made for bash, because it displays helpful debug messages (and it's as fast as you can dream).
+For development purposes, I'd recommend [bollux](https://tildegit.org/acdw/bollux), a browser made for bash, because it displays helpful debug messages (and it's as fast as you can dream).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For development purposes, I'd recommend [bollux](https://sr.ht/~acdw/bollux/), a
 
 `Gemeaux` is built around **the standard Python 3.9+ library** and syntax. There are **no external dependencies**.
 
-Automated tests are launched using Python 3.9, so the internals of `Gemeaux` are safe with these versions of Python.
+Automated tests are launched using Python 3.9, 3.10, 3.11, 3.12 and 3.13 so the internals of `Gemeaux` are safe with these versions of Python.
 
 You'll also need `openssl` to generate certificates.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 
 [options]
 zip_safe = false
-python_requires = >=3.8
+python_requires = >=3.9
 packages = gemeaux
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,10 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
 
 
 [options]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py38,py39
+envlist = lint,py39
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py39
+envlist = lint,py39,py310,py311,py312,py313
 
 [testenv]
 deps =


### PR DESCRIPTION
* Drop Python 3.8 support
* Confirm support for Python 3.10, 3.11, 3.12, 3.13
* Improve README by updating links and adding a nice badge for test runs